### PR TITLE
Some changes in  README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ ARTSS is a real-time and prognosis capable CFD code basis simulating buoyancy-dr
 based on finite differences and a large eddy simulation turbulence model. The open source code is portable on CPU and GPU and successfully verified using unit, analytical and
 semi-analytical tests. It is also successfully validated with scenarios relevant for fire protection.
 ARTSS is based on JuROr, which was originally developed within the [ORPHEUS](http://www.orpheus-projekt.de) project
-(funded through the [BMBF](https://www.bmbf.de/)) by Dr. Anne Küsters.
+(funded by [BMBF](https://www.bmbf.de/)) by Dr. Anne Küsters.
 
 ## Getting Started
 
 ### Requirements
 The serial CPU version of ARTSS can be compiled on Linux or MacOS systems with very few tools,
-whereas the multicore and GPU version need an OpenACC capable compiler.
+whereas the multicore and GPU version needs an OpenACC capable compiler.
 Detailed requirements are listed in the table below (general requirements for serial version, specific for multicore and GPU version).
 
 |          | Purpose                                             | Tool     | Version       |
@@ -21,22 +21,25 @@ Detailed requirements are listed in the table below (general requirements for se
 |          | Compiler fully supporting C++-17                    | gcc      |   >= 7.0      |
 |          |                                                     | clang    |   >= 8.0      |
 |          | Visualization of output                             | vtk      |   >= 5.8      |
-|          |                                                     | Paraview/|   VisIT       |
+|          |                                                     | Paraview |   VisIT       |
 |          | Testing for consistency of output while developing  | python   |   >= 3.6      |
 | Specific | Compiler fully supporting C++-17 and OpenACC        | PGI      |   >= 19.10    |
 
 ### Compiling the Code
-Once the code has been checked out and all required software has been loaded, JuROr
+Once the code has been checked out and all required software has been installed, JuROr
 can be built from the terminal by first running cmake to configure the build, then
 running make. The steps are summarized below.  
 
+1. Clone
 ```
-# 1. Clone
 git clone https://github.com/FireDynamics/ARTSS.git
 cd ARTSS
+```
+2. Compiling the code
 
-# 2. Compiling the code
+```
 ./compile.sh [OPTIONS]
+```
 
 OPTIONS (selection; show all by using --help flag):
 - '-s' -> Compile serial ARTSS version
@@ -47,13 +50,13 @@ OPTIONS (selection; show all by using --help flag):
 
 EXAMPLE:
 - Compile serial version of ARTSS using 4 cores and GCC
-'./compile.sh -s --jobs 4 --gcc'
+`./compile.sh -s --jobs 4 --gcc`
 - Compile multicore version of ARTSS
-'./compile.sh -m'
+`./compile.sh -m`
 
 Extra:
 It is also possible to compile ARTSS using a docker file. Instructions and further information can be found in the folder `docker`.
-```
+
 
 ### Code structure
 ```


### PR DESCRIPTION
- I think Git should not be a requirement since users can just download the code as a zip-file.
- paraview: Version = VisIT?
- From the table it is not clear if clang *and* gcc are needed.
- Are there some default values for the options? For example if --gcc is not used, what compiler is used?