### PR TITLE
Python3 syntax and usage for all run.sh and verify.sh files

### DIFF
--- a/tests/advection/run.sh
+++ b/tests/advection/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_Advection.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/burgers/run.sh
+++ b/tests/burgers/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_Burgers.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/diffusion/hat/run.sh
+++ b/tests/diffusion/hat/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_Diffusion_Hat.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/diffusion/hat/verify.py
+++ b/tests/diffusion/hat/verify.py
@@ -4,50 +4,50 @@ import numpy as np
 try:
     u = np.loadtxt("u.dat")
 except:
-    print "test failed, could not load data file u.dat"
+    print("test failed, could not load data file u.dat")
     sys.exit(1)
 
 try:
     v = np.loadtxt("v.dat")
 except:
-    print "test failed, could not load data file v.dat"
+    print("test failed, could not load data file v.dat")
     sys.exit(1)
     
 try:
 	w = np.loadtxt("w.dat")
 except:
-    print "test failed, could not load data file w.dat"
+    print("test failed, could not load data file w.dat")
     sys.exit(1)
 
 try:
     u_ref = np.loadtxt("u_ref.dat")
 except:
-    print "test failed, could not load data file u_ref.dat"
+    print("test failed, could not load data file u_ref.dat")
     sys.exit(1)
 
 try:
     v_ref = np.loadtxt("v_ref.dat")
 except:
-    print "test failed, could not load data file v_ref.dat"
+    print("test failed, could not load data file v_ref.dat")
     sys.exit(1)
 
 try:
     w_ref = np.loadtxt("w_ref.dat")
 except:
-    print "test failed, could not load data file w_ref.dat"
+    print("test failed, could not load data file w_ref.dat")
     sys.exit(1)
     
 l0 = u.shape
 
 if (v.shape != l0 or w.shape != l0 or u_ref.shape != l0 or v_ref.shape != l0 or w_ref.shape != l0):
-    print "test failed, data sizes do not match"
+    print("test failed, data sizes do not match")
     sys.exit(1)
 
 d = np.sum(np.sqrt((u-u_ref)**2 + (v-v_ref)**2 + (w-w_ref)**2))
 
 if d < 1e-6:
-    print "test passed"
+    print("test passed")
     sys.exit(0)
 else:
-    print "test failed, difference: ", d
+    print("test failed, difference:", d)
     sys.exit(1)

--- a/tests/diffusion/run.sh
+++ b/tests/diffusion/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_Diffusion.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/diffusionTurb/run.sh
+++ b/tests/diffusionTurb/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_DiffusionTurb.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/dissipation/run.sh
+++ b/tests/dissipation/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_Dissipation.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokes/cavityFlow/run.sh
+++ b/tests/navierStokes/cavityFlow/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesCavity.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokes/channelFlow/run.sh
+++ b/tests/navierStokes/channelFlow/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesChannel.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokes/mcDermott/run.sh
+++ b/tests/navierStokes/mcDermott/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesMcDermott.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokes/vortex/run.sh
+++ b/tests/navierStokes/vortex/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesVortex.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokesTemp/mms/run.sh
+++ b/tests/navierStokesTemp/mms/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesBuoyancyMMS.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokesTempTurb/dynamicBoundaries/run.sh
+++ b/tests/navierStokesTempTurb/dynamicBoundaries/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesTempTurbAdaption.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokesTempTurb/mms/run.sh
+++ b/tests/navierStokesTempTurb/mms/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesTempTurbBuoyancyMMS.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokesTurb/mcDermott/run.sh
+++ b/tests/navierStokesTurb/mcDermott/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesTurbMcDermott.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/navierStokesTurb/vortex/run.sh
+++ b/tests/navierStokesTurb/vortex/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_NavierStokesTurbVortex.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then

--- a/tests/pressure/run.sh
+++ b/tests/pressure/run.sh
@@ -2,7 +2,7 @@ $1 ./Test_Pressure.xml
 
 rm -rf *.vtk
 
-python ./verify.py
+python3 ./verify.py
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
because older systems associate with the python command python2, it should be defined as python3