### PR TITLE
Issue 12 segfault sladvect

### DIFF
--- a/src/advection/SLAdvect.cpp
+++ b/src/advection/SLAdvect.cpp
@@ -111,7 +111,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 if (i1 > i_end + 1) {
                     i1 = i_end + 1;
                 }
-                r = fabs(Ci - (long int) (Ci));
+                r = fabs(fmod(Ci, 1));
             } else {
                 i1 = i - (long int) (Ci);
                 if (i1 < i_start - 1) {
@@ -121,7 +121,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 if (i0 > i_end + 1) {
                     i0 = i_end + 1;
                 }
-                r = 1 - fabs(Ci - (long int) (Ci));
+                r = 1 - fabs(fmod(Ci, 1));
             }
 
             i0 = (size_t) i0;
@@ -141,7 +141,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 if (j1 > j_end + 1) {
                     j1 = j_end + 1;
                 }
-                s = fabs(Cj - (long int) (Cj));
+                s = fabs(fmod(Cj, 1));
             } else {
                 j1 = j - (long int) (Cj);
                 if (j1 < j_start - 1) {
@@ -151,7 +151,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 if (j0 > j_end + 1) {
                     j0 = j_end + 1;
                 }
-                s = 1 - fabs(Cj - (long int) (Cj));
+                s = 1 - fabs(fmod(Cj, 1));
             }
 
             j0 = (size_t) j0;
@@ -171,7 +171,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 if (k1 > k_end + 1) {
                     k1 = k_end + 1;
                 }
-                t = fabs(Ck - (long int) (Ck));
+                t = fabs(fmod(Ck, 1));
             } else {
                 k1 = k - (long int) (Ck);
                 if (k1 < k_start - 1) {
@@ -181,7 +181,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 if (k0 > k_end + 1) {
                     k0 = k_end + 1;
                 }
-                t = 1 - fabs(Ck - (long int) (Ck));
+                t = 1 - fabs(fmod(Ck, 1));
             }
 
             k0 = (size_t) k0;

--- a/src/advection/SLAdvect.cpp
+++ b/src/advection/SLAdvect.cpp
@@ -112,7 +112,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 i1 = i0 - 1;
                 r = fabs(fmod(Ci, 1));
             } else {
-                i1 = std::min(i_end - 1, i - static_cast<long int>(Ci));
+                i1 = std::min(i_end, i - static_cast<long int>(Ci));
                 i0 = i1 + 1;
                 r = 1 - fabs(fmod(Ci, 1));
             }
@@ -127,7 +127,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
                 j1 = j0 - 1;
                 s = fabs(fmod(Cj, 1));
             } else {
-                j1 = std::min(j_end - 1, j - static_cast<long int>(Cj));
+                j1 = std::min(j_end, j - static_cast<long int>(Cj));
                 j0 = j1 + 1;
                 s = 1 - fabs(fmod(Cj, 1));
             }
@@ -138,11 +138,11 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
             real t;
 
             if (Ck > 0) {
-                k0 = std::max(k_start, k - (long int) static_cast<long int>(Ck));
+                k0 = std::max(k_start, k - static_cast<long int>(Ck));
                 k1 = k0 - 1;
                 t = fabs(fmod(Ck, 1));
             } else {
-                k1 = std::min(k_end - 1, k - (long int) static_cast<long int>(Ck));
+                k1 = std::min(k_end, k - static_cast<long int>(Ck));
                 k0 = k1 + 1;
                 t = 1 - fabs(fmod(Ck, 1));
             }
@@ -157,7 +157,7 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
             size_t idx_010 = IX(i0, j1, k0, Nx, Ny);
             auto d_010 = d_in[idx_010];
 
-            size_t idx_110 = IX(i0, j0, k0, Nx, Ny);
+            size_t idx_110 = IX(i1, j1, k0, Nx, Ny);
             auto d_110 = d_in[idx_110];
 
             size_t idx_001 = IX(i0, j0, k1, Nx, Ny);

--- a/src/advection/SLAdvect.cpp
+++ b/src/advection/SLAdvect.cpp
@@ -13,8 +13,13 @@
 #ifdef _OPENACC
 #include <accelmath.h>
 #else
+
 #include <cmath>
+
 #endif
+
+#include <algorithm>
+#include <search.h>
 #include "SLAdvect.h"
 #include "../utility/Parameters.h"
 #include "../boundary/BoundaryController.h"
@@ -77,19 +82,19 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
         const real dtz = dt * rdz;
 
         //start indices for computational domain of inner cells
-        long i_start = static_cast<long> (domain->GetIndexx1());
-        long j_start = static_cast<long> (domain->GetIndexy1());
-        long k_start = static_cast<long> (domain->GetIndexz1());
-        long i_end = static_cast<long> (domain->GetIndexx2());
-        long j_end = static_cast<long> (domain->GetIndexy2());
-        long k_end = static_cast<long> (domain->GetIndexz2());
+        long int i_start = static_cast<long int> (domain->GetIndexx1());
+        long int j_start = static_cast<long int> (domain->GetIndexy1());
+        long int k_start = static_cast<long int> (domain->GetIndexz1());
+        long int i_end = static_cast<long int> (domain->GetIndexx2());
+        long int j_end = static_cast<long int> (domain->GetIndexy2());
+        long int k_end = static_cast<long int> (domain->GetIndexz2());
 
 #pragma acc parallel loop independent present(d_out[:bsize], d_in[:bsize], d_u_vel[:bsize], d_v_vel[:bsize], d_w_vel[:bsize], d_iList[:bsize_i]) async
         for (size_t l = 0; l < bsize_i; ++l) {
             const size_t idx = d_iList[l];
-            const long k = static_cast<long> (getCoordinateK(idx, Nx, Ny));
-            const long j = static_cast<long> (getCoordinateJ(idx, Nx, Ny, k));
-            const long i = static_cast<long> (getCoordinateI(idx, Nx, Ny, j, k));
+            const long int k = static_cast<long int> (getCoordinateK(idx, Nx, Ny));
+            const long int j = static_cast<long int> (getCoordinateJ(idx, Nx, Ny, k));
+            const long int i = static_cast<long int> (getCoordinateI(idx, Nx, Ny, j, k));
 
             //TODO: backtracking may be outside the computational region, it is not a reasonable solution to cut the vector; idea: enlarge ghost cell to CFL*dx
             // Linear Trace Back
@@ -98,100 +103,78 @@ void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_
             real Ck = dtz * d_w_vel[idx];
 
             // Calculation of horizontal indices and interpolation weights
-            long int i0 = 0;
-            long int i1 = 0;
+            long int i0;
+            long int i1;
             real r;
 
             if (Ci > 0) {
-                i0 = i - (long int) (Ci);    // to round correctly
-                if (i0 < i_start) {
-                    i0 = i_start;
-                }
+                i0 = std::max(i_start, (i - static_cast<long int>(Ci)));
                 i1 = i0 - 1;
-                if (i1 > i_end + 1) {
-                    i1 = i_end + 1;
-                }
                 r = fabs(fmod(Ci, 1));
             } else {
-                i1 = i - (long int) (Ci);
-                if (i1 < i_start - 1) {
-                    i1 = i_start - 1;
-                }
+                i1 = std::min(i_end - 1, i - static_cast<long int>(Ci));
                 i0 = i1 + 1;
-                if (i0 > i_end + 1) {
-                    i0 = i_end + 1;
-                }
                 r = 1 - fabs(fmod(Ci, 1));
             }
 
-            i0 = (size_t) i0;
-            i1 = (size_t) i1;
-
             //Calculation of vertical indices and interpolation weights
-            long int j0 = 0;
-            long int j1 = 0;
+            long int j0;
+            long int j1;
             real s;
 
             if (Cj > 0) {
-                j0 = j - (long int) (Cj);    // to round correctly
-                if (j0 < j_start) {
-                    j0 = j_start;
-                }
+                j0 = std::max(j_start, j - static_cast<long int>(Cj));
                 j1 = j0 - 1;
-                if (j1 > j_end + 1) {
-                    j1 = j_end + 1;
-                }
                 s = fabs(fmod(Cj, 1));
             } else {
-                j1 = j - (long int) (Cj);
-                if (j1 < j_start - 1) {
-                    j1 = j_start - 1;
-                }
+                j1 = std::min(j_end - 1, j - static_cast<long int>(Cj));
                 j0 = j1 + 1;
-                if (j0 > j_end + 1) {
-                    j0 = j_end + 1;
-                }
                 s = 1 - fabs(fmod(Cj, 1));
             }
 
-            j0 = (size_t) j0;
-            j1 = (size_t) j1;
-
             //Calculation of depth indices and interpolation weights
-            long int k0 = 0;
-            long int k1 = 0;
+            long int k0;
+            long int k1;
             real t;
 
             if (Ck > 0) {
-                k0 = k - (long int) (Ck);    // to round correctly
-                if (k0 < k_start) {
-                    k0 = k_start;
-                }
+                k0 = std::max(k_start, k - (long int) static_cast<long int>(Ck));
                 k1 = k0 - 1;
-                if (k1 > k_end + 1) {
-                    k1 = k_end + 1;
-                }
                 t = fabs(fmod(Ck, 1));
             } else {
-                k1 = k - (long int) (Ck);
-                if (k1 < k_start - 1) {
-                    k1 = k_start - 1;
-                }
+                k1 = std::min(k_end - 1, k - (long int) static_cast<long int>(Ck));
                 k0 = k1 + 1;
-                if (k0 > k_end + 1) {
-                    k0 = k_end + 1;
-                }
                 t = 1 - fabs(fmod(Ck, 1));
             }
 
-            k0 = (size_t) k0;
-            k1 = (size_t) k1;
-
             // Trilinear Interpolation
-            d_out[idx] = (1. - t) * ((1. - s) * ((1. - r) * d_in[IX(i0, j0, k0, Nx, Ny)] + r * d_in[IX(i1, j0, k0, Nx, Ny)])
-                                     + s * ((1. - r) * d_in[IX(i0, j1, k0, Nx, Ny)] + r * d_in[IX(i1, j1, k0, Nx, Ny)]))
-                         + t * ((1. - s) * ((1. - r) * d_in[IX(i0, j0, k1, Nx, Ny)] + r * d_in[IX(i1, j0, k1, Nx, Ny)])
-                                + s * ((1. - r) * d_in[IX(i0, j1, k1, Nx, Ny)] + r * d_in[IX(i1, j1, k1, Nx, Ny)])); //row-major
+            size_t idx_000 = IX(i0, j0, k0, Nx, Ny);
+            auto d_000 = d_in[idx_000];
+
+            size_t idx_100 = IX(i1, j0, k0, Nx, Ny);
+            auto d_100 = d_in[idx_100];
+
+            size_t idx_010 = IX(i0, j1, k0, Nx, Ny);
+            auto d_010 = d_in[idx_010];
+
+            size_t idx_110 = IX(i0, j0, k0, Nx, Ny);
+            auto d_110 = d_in[idx_110];
+
+            size_t idx_001 = IX(i0, j0, k1, Nx, Ny);
+            auto d_001 = d_in[idx_001];
+
+            size_t idx_101 = IX(i1, j0, k1, Nx, Ny);
+            auto d_101 = d_in[idx_101];
+
+            size_t idx_011 = IX(i0, j1, k1, Nx, Ny);
+            auto d_011 = d_in[idx_011];
+
+            size_t idx_111 = IX(i1, j1, k1, Nx, Ny);
+            auto d_111 = d_in[idx_111];
+            d_out[idx] = (1. - t) * ((1. - s) * ((1. - r) * d_000 + r * d_100)
+                                     + s * ((1. - r) * d_010 + r * d_110))
+                         + t * ((1. - s) * ((1. - r) * d_001 + r * d_101)
+                                + s * ((1. - r) * d_011 + r * d_111)); //row-major
         }
 
         boundary->applyBoundary(d_out, type, sync);

--- a/src/advection/SLAdvect.cpp
+++ b/src/advection/SLAdvect.cpp
@@ -1,13 +1,13 @@
-/// \file 		SLAdvect.cpp
-/// \brief 		Solves advection equation via unconditionally stable Semi-Lagrangian approach
-/// \date 		Aug 23, 2016
-/// \author 	Severt
-/// \copyright 	<2015-2020> Forschungszentrum Juelich GmbH. All rights reserved.
+/// \file       SLAdvect.cpp
+/// \brief      Solves advection equation via unconditionally stable Semi-Lagrangian approach
+/// \date       Aug 23, 2016
+/// \author     Severt
+/// \copyright  <2015-2020> Forschungszentrum Juelich GmbH. All rights reserved.
 
 //==================================== Semi Lagrangian Advection ======================================
 // ***************************************************************************************
 /// \brief  solves advection \f$ \partial_t \phi_1 = - (u \cdot \nabla) \phi_0 \f$ via unconditionally
-///			stable semi-Lagrangian approach (backtrace and linear interpolation)
+///         stable semi-Lagrangian approach (backtrace and linear interpolation)
 // ***************************************************************************************
 
 #ifdef _OPENACC
@@ -32,13 +32,13 @@ SLAdvect::SLAdvect() {
 
 // ***************************************************************************************
 /// \brief  solves advection \f$ \partial_t \phi_1 = - (u \cdot \nabla) \phi_0 \f$ via unconditionally
-///			stable semi-Lagrangian approach (backtrace and linear interpolation)
-/// \param  out		output pointer
-/// \param	in		input pointer
-/// \param	u_vel	x -velocity
-/// \param	v_vel	y -velocity
-/// \param	w_vel	z -velocity
-/// \param  sync	synchronization boolean (true=sync (default), false=async)
+///     stable semi-Lagrangian approach (backtrace and linear interpolation)
+/// \param  out   output pointer
+/// \param  in    input pointer
+/// \param  u_vel x -velocity
+/// \param  v_vel y -velocity
+/// \param  w_vel z -velocity
+/// \param  sync  synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
 void SLAdvect::advect(Field *out, Field *in, const Field *u_vel, const Field *v_vel, const Field *w_vel, bool sync) {
 

--- a/src/boundary/Multigrid.cpp
+++ b/src/boundary/Multigrid.cpp
@@ -874,12 +874,16 @@ void Multigrid::sendObstacleListsToGPU() {
         //std::cout << "control sendMGListsToGPU obstacle Top " << counter_oTop + 1 << "|" << size_oTop << std::endl;
         //std::cout << "control sendMGListsToGPU obstacle Left " << counter_oLeft + 1 << "|" << size_oLeft << std::endl;
         //std::cout << "control sendMGListsToGPU obstacle Right " << counter_oRight + 1 << "|" << size_oRight << std::endl;
+
+        m_data_MG_oList_zero_joined = m_MG_oList[0];
+        size_t size_oList = getSize_obstacleList();
 #pragma acc enter data copyin(m_data_MG_oFront_level_joined[:size_oFront])
 #pragma acc enter data copyin(m_data_MG_oBack_level_joined[:size_oBack])
 #pragma acc enter data copyin(m_data_MG_oTop_level_joined[:size_oTop])
 #pragma acc enter data copyin(m_data_MG_oBottom_level_joined[:size_oBottom])
 #pragma acc enter data copyin(m_data_MG_oLeft_level_joined[:size_oLeft])
 #pragma acc enter data copyin(m_data_MG_oRight_level_joined[:size_oRight])
+#pragma acc enter data copyin(m_data_MG_oList_zero_joined[:size_oList])
     }
 }
 

--- a/src/boundary/Multigrid.h
+++ b/src/boundary/Multigrid.h
@@ -107,6 +107,7 @@ private:
     size_t* m_data_MG_oBottom_level_joined;
     size_t* m_data_MG_oLeft_level_joined;
     size_t* m_data_MG_oRight_level_joined;
+    size_t* m_data_MG_oList_zero_joined;
 
     size_t getSize_oList(size_t level);
     size_t getLastIndex_oFront( size_t level, size_t id);


### PR DESCRIPTION
- replaced if queries with max/min with computational domain bounds to prevent out of bounds access
- dividing the one-liner of the triangulation expression for better readability 