### PR TITLE
Changed the naming of Interfaces

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,45 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-gcc-serial:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: compile
+      run: |
+        git submodule update --init
+        ./compile.sh --jobs 4 --gcc -s
+        
+  build-pgi-multicore:
+    
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compile
+        run: |
+          git submodule update --init
+          cd docker
+          docker build -t artss_docker .
+          cd ..
+          docker run -i --rm -v $(pwd):/host_pwd -w /host_pwd artss_docker ./compile.sh -m --jobs 4
+          
+  build-pgi-serial:
+    
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: compile
+        run: |
+          git submodule update --init
+          cd docker
+          docker build -t artss_docker .
+          cd ..
+          docker run -i --rm -v $(pwd):/host_pwd -w /host_pwd artss_docker ./compile.sh --jobs 4 -s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,9 +175,9 @@ set(SOURCE_FILES
         "src/diffusion/ExplicitDiffuse.cpp"
         "src/diffusion/JacobiDiffuse.cpp"
 
-        "src/interfaces/PressureI.cpp"
-        "src/interfaces/SolverI.cpp"
-        "src/interfaces/SourceI.cpp"
+        "src/interfaces/IPressure.cpp"
+        "src/interfaces/ISolver.cpp"
+        "src/interfaces/ISource.cpp"
 
         "src/pressure/VCycleMG.cpp"
 
@@ -237,13 +237,13 @@ set(HEADER_FILES
         "src/diffusion/ExplicitDiffuse.h"
         "src/diffusion/JacobiDiffuse.h"
 
-        "src/interfaces/AdaptionFunctionI.h"
-        "src/interfaces/advectionI.h"
-        "src/interfaces/diffusionI.h"
-        "src/interfaces/PressureI.h"
-        "src/interfaces/SolverI.h"
-        "src/interfaces/SourceI.h"
-        "src/interfaces/TurbulenceI.h"
+        "src/interfaces/IAdaptionFunction.h"
+        "src/interfaces/IAdvection.h"
+        "src/interfaces/IDiffusion.h"
+        "src/interfaces/IPressure.h"
+        "src/interfaces/ISolver.h"
+        "src/interfaces/ISource.h"
+        "src/interfaces/ITurbulence.h"
 
         "src/pressure/VCycleMG.h"
 

--- a/src/TimeIntegration.cpp
+++ b/src/TimeIntegration.cpp
@@ -24,7 +24,7 @@
 /// \param  isolv	pointer to solver
 /// \param  fname	filename of xml-input (via argument)
 // ***************************************************************************************
-TimeIntegration::TimeIntegration(SolverI *isolv, const char *fname) {
+TimeIntegration::TimeIntegration(ISolver *isolv, const char *fname) {
 	auto params = Parameters::getInstance();
 	auto domain = Domain::getInstance();
 
@@ -175,6 +175,8 @@ void TimeIntegration::run(){
 
 		// Calculate
 		m_solver->DoStep(t_cur, false);
+
+		//TODO: UDP FIRIN HERE
 
 		// Visualize
 #ifndef PROFILING

--- a/src/TimeIntegration.h
+++ b/src/TimeIntegration.h
@@ -7,19 +7,19 @@
 #ifndef ARTSS_TIMEINTEGRATION_H_
 #define ARTSS_TIMEINTEGRATION_H_
 
-#include "interfaces/SolverI.h"
-#include "interfaces/SourceI.h"
+#include "interfaces/ISolver.h"
+#include "interfaces/ISource.h"
 #include "utility/GlobalMacrosTypes.h"
 #include "analysis/Analysis.h"
 
 class TimeIntegration {
 public:
-	TimeIntegration(SolverI *isolv, const char *fname);
+	TimeIntegration(ISolver *isolv, const char *fname);
 
 	void run();
 
 private:
-	SolverI* m_solver;
+	ISolver* m_solver;
 	const char *m_fname;
 	real m_dt;
 	real m_t_end;

--- a/src/adaption/Adaption.h
+++ b/src/adaption/Adaption.h
@@ -9,7 +9,7 @@
 
 
 #include "../Field.h"
-#include "../interfaces/AdaptionFunctionI.h"
+#include "../interfaces/IAdaptionFunction.h"
 #include "../utility/GlobalMacrosTypes.h"
 
 /* enum for different types of dynamic adaption:
@@ -52,7 +52,7 @@ enum VectorFieldsTypes : size_t {
 
 class Field;
 
-class AdaptionFunctionI;
+class IAdaptionFunction;
 
 class Adaption {
 public:
@@ -118,7 +118,7 @@ private:
 
     void applyChanges();
 
-    AdaptionFunctionI *func;
+    IAdaptionFunction *func;
     bool m_dynamic, m_dynamic_end;
     bool m_reduction;
     bool m_hasDataExtraction;

--- a/src/adaption/Layers.h
+++ b/src/adaption/Layers.h
@@ -10,9 +10,9 @@
 
 #include "../utility/GlobalMacrosTypes.h"
 #include "../Field.h"
-#include "../interfaces/AdaptionFunctionI.h"
+#include "../interfaces/IAdaptionFunction.h"
 
-class Layers:public AdaptionFunctionI {
+class Layers:public IAdaptionFunction {
 public:
     Layers(Adaption* pAdaption, Field** fields);
     ~Layers();

--- a/src/adaption/Vortex.h
+++ b/src/adaption/Vortex.h
@@ -8,11 +8,11 @@
 #define ARTSS_ADAPTION_VORTEX_H_
 
 
-#include "../interfaces/AdaptionFunctionI.h"
+#include "../interfaces/IAdaptionFunction.h"
 #include "Adaption.h"
 
 
-class Vortex : public AdaptionFunctionI {
+class Vortex : public IAdaptionFunction {
 public:
     Vortex(Adaption *pAdaption, Field **fields);
     ~Vortex();

--- a/src/advection/ExplicitAdvect.h
+++ b/src/advection/ExplicitAdvect.h
@@ -7,11 +7,11 @@
 #ifndef ARTSS_ADVECTION_EXPLICITADVECT_H_
 #define ARTSS_ADVECTION_EXPLICITADVECT_H_
 
-#include "../interfaces/AdvectionI.h"
+#include "../interfaces/IAdvection.h"
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class ExplicitAdvect: public AdvectionI {
+class ExplicitAdvect: public IAdvection {
 public:
 	ExplicitAdvect();
     ~ExplicitAdvect() override = default;

--- a/src/advection/SLAdvect.h
+++ b/src/advection/SLAdvect.h
@@ -7,11 +7,11 @@
 #ifndef ARTSS_ADVECTION_SLADVECT_H_
 #define ARTSS_ADVECTION_SLADVECT_H_
 
-#include "../interfaces/AdvectionI.h"
+#include "../interfaces/IAdvection.h"
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class SLAdvect: public AdvectionI {
+class SLAdvect: public IAdvection {
 public:
 	SLAdvect();
     ~SLAdvect() override = default;

--- a/src/analysis/Analysis.cpp
+++ b/src/analysis/Analysis.cpp
@@ -14,7 +14,7 @@
 #include "../boundary/BoundaryController.h"
 #include "../boundary/BoundaryData.h"
 #include "Solution.h"
-#include "../interfaces/SolverI.h"
+#include "../interfaces/ISolver.h"
 #include "../utility/Parameters.h"
 #include "../Domain.h"
 
@@ -35,7 +35,7 @@ Analysis::Analysis() {
 /// \param	solver		pointer to solver
 /// \param	t			current time
 // ***************************************************************************************
-void Analysis::Analyse(SolverI *solver, const real t) {
+void Analysis::Analyse(ISolver *solver, const real t) {
     //TODO statement t == 0.
     Solution solution;
 
@@ -233,7 +233,7 @@ real Analysis::CalcRelativeSpatialError(read_ptr num, read_ptr ana) {
 /// \param	t			current time
 /// \param	sum			pointer to sum for (u,p,T results)
 // ***************************************************************************************
-void Analysis::CalcL2NormMidPoint(SolverI *solver, real t, real *sum) {
+void Analysis::CalcL2NormMidPoint(ISolver *solver, real t, real *sum) {
     Solution solution;
 
     auto boundary = BoundaryController::getInstance();
@@ -429,7 +429,7 @@ real Analysis::SetDTwithCFL(Field *u, Field *v, Field *w) {
 /// \brief  saves variables in .dat files
 /// \param	solv		pointer to solver
 // ***************************************************************************************
-void Analysis::SaveVariablesInFile(SolverI *solv) {
+void Analysis::SaveVariablesInFile(ISolver *solv) {
     //TODO do not write field out if not used
     auto boundary = BoundaryController::getInstance();
     size_t *innerList = boundary->get_innerList_level_joined();

--- a/src/analysis/Analysis.h
+++ b/src/analysis/Analysis.h
@@ -7,21 +7,21 @@
 #ifndef ARTSS_ANALYSIS_ANALYSIS_H_
 #define ARTSS_ANALYSIS_ANALYSIS_H_
 
-#include "../interfaces/SolverI.h"
+#include "../interfaces/ISolver.h"
 #include "../utility/GlobalMacrosTypes.h"
 
 class Analysis {
 public:
 	Analysis();
 
-	void Analyse(SolverI* solver, real t);
+	void Analyse(ISolver* solver, real t);
 	//real* CalcL2NormMidPoint(real t, real* sum, read_ptr num_u, read_ptr num_p, read_ptr num_T);
-	void CalcL2NormMidPoint(SolverI* solver, real t, real* sum);
+	void CalcL2NormMidPoint(ISolver* solver, real t, real* sum);
 	void CalcRMSError(real sumu, real sump, real sumT);
 	bool CheckTimeStepVN(Field* u, real dt);
 	bool CheckTimeStepCFL(Field* u, Field* v, Field* w, real dt);
 	real SetDTwithCFL(Field* u, Field* v, Field* w);
-	void SaveVariablesInFile(SolverI* solv);
+	void SaveVariablesInFile(ISolver* solv);
 
 private:
 	real m_tol = 1e-7;

--- a/src/diffusion/ColoredGaussSeidelDiffuse.h
+++ b/src/diffusion/ColoredGaussSeidelDiffuse.h
@@ -8,10 +8,10 @@
 #ifndef ARTSS_DIFFUSION_COLOREDGAUSSSEIDEL_H
 #define ARTSS_DIFFUSION_COLOREDGAUSSSEIDEL_H
 
-#include "../interfaces/DiffusionI.h"
+#include "../interfaces/IDiffusion.h"
 #include "../Field.h"
 
-class ColoredGaussSeidelDiffuse: public DiffusionI {
+class ColoredGaussSeidelDiffuse: public IDiffusion {
 public:
     ColoredGaussSeidelDiffuse();
 

--- a/src/diffusion/ExplicitDiffuse.h
+++ b/src/diffusion/ExplicitDiffuse.h
@@ -7,10 +7,10 @@
 #ifndef ARTSS_DIFFUSION_EXPLICITDIFFUSE_H_
 #define ARTSS_DIFFUSION_EXPLICITDIFFUSE_H_
 
-#include "../interfaces/DiffusionI.h"
+#include "../interfaces/IDiffusion.h"
 #include "../Field.h"
 
-class ExplicitDiffuse: public DiffusionI {
+class ExplicitDiffuse: public IDiffusion {
 public:
 	ExplicitDiffuse();
 

--- a/src/diffusion/JacobiDiffuse.h
+++ b/src/diffusion/JacobiDiffuse.h
@@ -8,10 +8,10 @@
 #ifndef ARTSS_DIFFUSION_JACOBIDIFFUSE_H_
 #define ARTSS_DIFFUSION_JACOBIDIFFUSE_H_
 
-#include "../interfaces/DiffusionI.h"
+#include "../interfaces/IDiffusion.h"
 #include "../Field.h"
 
-class JacobiDiffuse: public DiffusionI {
+class JacobiDiffuse: public IDiffusion {
 public:
 	JacobiDiffuse();
 

--- a/src/interfaces/IAdaptionFunction.h
+++ b/src/interfaces/IAdaptionFunction.h
@@ -8,7 +8,7 @@
 #define ARTSS_INTERFACE_ADPATIONFUNCTIONI_H
 
 
-class AdaptionFunctionI {
+class IAdaptionFunction {
 public:
     virtual void applyChanges() = 0;
     virtual bool update() = 0;

--- a/src/interfaces/IAdvection.h
+++ b/src/interfaces/IAdvection.h
@@ -9,11 +9,11 @@
 
 #include "../Field.h"
 
-class AdvectionI {
+class IAdvection {
 
 public:
-	AdvectionI() = default;
-	virtual ~AdvectionI() = default;
+	IAdvection() = default;
+	virtual ~IAdvection() = default;
 
 	virtual void advect(Field* out, Field* in, const Field* u_vel, const Field* v_vel, const Field* w_vel, bool sync)=0;
 };

--- a/src/interfaces/IDiffusion.h
+++ b/src/interfaces/IDiffusion.h
@@ -10,11 +10,11 @@
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class DiffusionI {
+class IDiffusion {
 
 public:
-    DiffusionI() = default;
-    virtual ~DiffusionI() = default;
+    IDiffusion() = default;
+    virtual ~IDiffusion() = default;
 
     virtual void diffuse(Field *out, Field *in, const Field *b, const real D, bool sync) = 0;
     virtual void diffuse(Field *out, Field *in, const Field *b, const real D, const Field *ev, bool sync) = 0;

--- a/src/interfaces/IPressure.cpp
+++ b/src/interfaces/IPressure.cpp
@@ -4,7 +4,7 @@
 /// \author 	Severt
 /// \copyright 	<2015-2020> Forschungszentrum Juelich GmbH. All rights reserved.
 
-#include "PressureI.h"
+#include "IPressure.h"
 #include "../utility/Parameters.h"
 #include "../Domain.h"
 #include "../boundary/BoundaryController.h"
@@ -18,7 +18,7 @@
 /// \param  in_z	input pointer (z -velocity)
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void PressureI::Divergence(Field *out, const Field *inx, const Field *iny, const Field *inz, bool sync) {
+void IPressure::Divergence(Field *out, const Field *inx, const Field *iny, const Field *inz, bool sync) {
 
     auto domain = Domain::getInstance();
 
@@ -85,7 +85,7 @@ void PressureI::Divergence(Field *out, const Field *inx, const Field *iny, const
 /// \param  in_p	input pointer (pressure)
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void PressureI::Project(Field *outu, Field *outv, Field *outw, const Field *inu, const Field *inv, const Field *inw, const Field *inp, bool sync) {
+void IPressure::Project(Field *outu, Field *outv, Field *outw, const Field *inu, const Field *inv, const Field *inw, const Field *inp, bool sync) {
 
     auto domain = Domain::getInstance();
     // local variables and parameters for GPU

--- a/src/interfaces/IPressure.h
+++ b/src/interfaces/IPressure.h
@@ -9,10 +9,10 @@
 
 #include "../Field.h"
 
-class PressureI {
+class IPressure {
 public:
-	PressureI() = default;
-	virtual ~PressureI() = default;
+	IPressure() = default;
+	virtual ~IPressure() = default;
 
 	virtual void pressure(Field* out, Field* b, real t, bool sync)=0;
 

--- a/src/interfaces/ISolver.cpp
+++ b/src/interfaces/ISolver.cpp
@@ -7,16 +7,16 @@
 #include <cmath>
 #include <iostream>
 
-#include "SolverI.h"
+#include "ISolver.h"
 #include "../utility/Parameters.h"
 #include "../Functions.h"
-#include "SourceI.h"
+#include "ISource.h"
 #include "../source/ExplicitEulerSource.h"
 #include "../Domain.h"
 #include "../boundary/BoundaryController.h"
 #include "../solver/SolverSelection.h"
 
-SolverI::SolverI() {
+ISolver::ISolver() {
     auto params = Parameters::getInstance();
 
     // Variables
@@ -117,7 +117,7 @@ SolverI::SolverI() {
 
 // ==================================== Destructor ====================================
 // ***************************************************************************************
-SolverI::~SolverI() {
+ISolver::~ISolver() {
     delete u;
     delete v;
     delete w;
@@ -175,7 +175,7 @@ SolverI::~SolverI() {
 // ***************************************************************************************
 /// \brief  initializes numerical and temporary solution
 // ***************************************************************************************
-void SolverI::SetUp() {
+void ISolver::SetUp() {
     std::cout << "Start initializing....\n" << std::endl;
     //TODO Logger
 
@@ -201,7 +201,7 @@ void SolverI::SetUp() {
 // ***************************************************************************************
 /// \brief  initializes variables \a u, \a v, \a p, \a d, \a T at \f$ t=0 \f$
 // ***************************************************************************************
-void SolverI::Init() {
+void ISolver::Init() {
 
     auto params = Parameters::getInstance();
     std::string string_init_usr_fct = params->get("initial_conditions/usr_fct");
@@ -435,7 +435,7 @@ void SolverI::Init() {
 /// \param	out		output pointer
 /// \param	in		input pointer
 // ***************************************************************************************
-void SolverI::Init_f(Field *out, const real *in) {
+void ISolver::Init_f(Field *out, const real *in) {
 
     auto boundary = BoundaryController::getInstance();
 
@@ -469,7 +469,7 @@ void SolverI::Init_f(Field *out, const real *in) {
 /// \param	out		output pointer
 /// \param	in		constant real value
 // ***************************************************************************************
-void SolverI::Init_c(Field *out, const real in) {
+void ISolver::Init_c(Field *out, const real in) {
 
     auto boundary = BoundaryController::getInstance();
 
@@ -502,7 +502,7 @@ void SolverI::Init_c(Field *out, const real in) {
 /// \brief  initializes boundary cells
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SolverI::SetUpBoundary(bool sync) {
+void ISolver::SetUpBoundary(bool sync) {
 
     auto boundary = BoundaryController::getInstance();
 
@@ -542,7 +542,7 @@ void SolverI::SetUpBoundary(bool sync) {
 /// \param  c_tmp	temporal field in z- direction
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SolverI::CoupleVector(const Field *a, Field *a0, Field *a_tmp, const Field *b, Field *b0, Field *b_tmp, const Field *c, Field *c0, Field *c_tmp, bool sync) {
+void ISolver::CoupleVector(const Field *a, Field *a0, Field *a_tmp, const Field *b, Field *b0, Field *b_tmp, const Field *c, Field *c0, Field *c_tmp, bool sync) {
 
     // local variables and parameters for GPU
     auto d_a = a->data;
@@ -620,7 +620,7 @@ void SolverI::CoupleVector(const Field *a, Field *a0, Field *a_tmp, const Field 
 /// \param  a_tmp	temporal field in x- direction
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SolverI::CoupleScalar(const Field *a, Field *a0, Field *a_tmp, bool sync) {
+void ISolver::CoupleScalar(const Field *a, Field *a0, Field *a_tmp, bool sync) {
 
     // local variables and parameters for GPU
     auto d_a = a->data;
@@ -675,7 +675,7 @@ void SolverI::CoupleScalar(const Field *a, Field *a0, Field *a_tmp, bool sync) {
 /// \brief  Updates variables for the next iteration step or time dependent parameters such as temperature source function
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SolverI::UpdateData(bool sync) {
+void ISolver::UpdateData(bool sync) {
 
     // local variables and parameters for GPU
     auto bsize = Domain::getInstance()->GetSize();
@@ -775,7 +775,7 @@ void SolverI::UpdateData(bool sync) {
 /// \param	t		time
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SolverI::UpdateSources(real t, bool sync) {
+void ISolver::UpdateSources(real t, bool sync) {
 
     auto params = Parameters::getInstance();
 
@@ -902,7 +902,7 @@ void SolverI::UpdateSources(real t, bool sync) {
 // ***************************************************************************************
 /// \brief  Updates time dependent parameters temperature source functions
 // ***************************************************************************************
-void SolverI::TemperatureSource() {
+void ISolver::TemperatureSource() {
 // Temperature source
     if (Parameters::getInstance()->get("solver/temperature/source/temp_fct") == FunctionNames::BuoyancyST_MMS) {
         Functions::BuoyancyST_MMS(S_T, 0.);
@@ -913,7 +913,7 @@ void SolverI::TemperatureSource() {
 // ***************************************************************************************
 /// \brief  Updates time dependent parameters force source functions
 // ***************************************************************************************
-void SolverI::ForceSource() {
+void ISolver::ForceSource() {
     auto params = Parameters::getInstance();
     // Force
     if (params->get("solver/source/force_fct") == SourceMethods::Buoyancy) {
@@ -936,7 +936,7 @@ void SolverI::ForceSource() {
 // ***************************************************************************************
 /// \brief  Updates time dependent parameters momentum source functions
 // ***************************************************************************************
-void SolverI::MomentumSource() {
+void ISolver::MomentumSource() {
     //Momentum source
     auto params = Parameters::getInstance();
     std::string dir_vel = params->get("solver/source/dir");

--- a/src/interfaces/ISolver.h
+++ b/src/interfaces/ISolver.h
@@ -9,7 +9,7 @@
 
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
-#include "SourceI.h"
+#include "ISource.h"
 
 struct SolverTypes {
     inline static const std::string AdvectionSolver = "AdvectionSolver";
@@ -25,10 +25,10 @@ struct SolverTypes {
     inline static const std::string PressureSolver = "PressureSolver";
 };
 
-class SolverI {
+class ISolver {
 public:
-	SolverI();
-	virtual ~SolverI();
+	ISolver();
+	virtual ~ISolver();
 
 	virtual void DoStep(real t, bool sync)=0;
 
@@ -130,9 +130,9 @@ public:
 
 	Field* sight;
 
-	SourceI* sou_temp;
-	SourceI* sou_vel;
-	SourceI* sou_con;
+	ISource* sou_temp;
+	ISource* sou_vel;
+	ISource* sou_con;
 
 protected:
 	void SetUp();

--- a/src/interfaces/ISource.cpp
+++ b/src/interfaces/ISource.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #endif
 
-#include "SourceI.h"
+#include "ISource.h"
 #include "../utility/Parameters.h"
 #include "../Domain.h"
 #include "../boundary/BoundaryController.h"
@@ -24,7 +24,7 @@
 /// \param  ina	ambient temperature
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SourceI::BuoyancyForce(Field *out, const Field *in, const Field *ina, bool sync) {
+void ISource::BuoyancyForce(Field *out, const Field *in, const Field *ina, bool sync) {
 
     // local variables and parameters for GPU
     auto d_out = out->data;
@@ -79,7 +79,7 @@ void SourceI::BuoyancyForce(Field *out, const Field *in, const Field *ina, bool 
 /// \param  t		time
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SourceI::BuoyancyST_MMS(Field *out, real t, bool sync) {
+void ISource::BuoyancyST_MMS(Field *out, real t, bool sync) {
     auto domain = Domain::getInstance();
     // local variables and parameters for GPU
     auto d_out = out->data;
@@ -156,7 +156,7 @@ void SourceI::BuoyancyST_MMS(Field *out, real t, bool sync) {
 /// \param  sigma	Radius of Gaussian
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SourceI::Gauss(Field *out, real HRR, real cp, real x0, real y0, real z0, real sigmax, real sigmay, real sigmaz, bool sync) {
+void ISource::Gauss(Field *out, real HRR, real cp, real x0, real y0, real z0, real sigmax, real sigmay, real sigmaz, bool sync) {
 
     auto domain = Domain::getInstance();
     // local variables and parameters for GPU
@@ -243,7 +243,7 @@ void SourceI::Gauss(Field *out, real HRR, real cp, real x0, real y0, real z0, re
 /// \param  in_w	input pointer (\a z -velocity)
 /// \param  sync	synchronization boolean (true=sync (default), false=async)
 // ***************************************************************************************
-void SourceI::Dissipate(Field *out, const Field *inu, const Field *inv, const Field *inw, bool sync) {
+void ISource::Dissipate(Field *out, const Field *inu, const Field *inv, const Field *inw, bool sync) {
 
     // local variables and parameters for GPU
     auto d_out = out->data;

--- a/src/interfaces/ISource.h
+++ b/src/interfaces/ISource.h
@@ -10,10 +10,10 @@
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class SourceI {
+class ISource {
 public:
-	SourceI() = default;
-	virtual ~SourceI() = default;
+	ISource() = default;
+	virtual ~ISource() = default;
 
 	virtual void addSource(Field* outx, Field* outy, Field* outz, Field* Sx, Field* Sy, Field* Sz, bool sync)=0;
 	virtual void addSource(Field* out, Field* S, bool sync)=0;

--- a/src/interfaces/ITurbulence.h
+++ b/src/interfaces/ITurbulence.h
@@ -9,11 +9,11 @@
 
 #include "../Field.h"
 
-class TurbulenceI {
+class ITurbulence {
 
 public:
-	TurbulenceI() = default;
-	virtual ~TurbulenceI() = default;
+	ITurbulence() = default;
+	virtual ~ITurbulence() = default;
 
 	virtual void CalcTurbViscosity(Field* ev, Field* in_u, Field* in_v, Field* in_w, bool sync)=0;
 	virtual void ExplicitFiltering(Field* out, const Field* in, bool sync)=0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
 /// \copyright 	<2015-2020> Forschungszentrum Juelich GmbH. All rights reserved.
 
 #include <iostream>
-#include "interfaces/SolverI.h"
+#include "interfaces/ISolver.h"
 #include "solver/DiffusionTurbSolver.h"
 #include "solver/DiffusionSolver.h"
 #include "solver/AdvectionSolver.h"
@@ -40,7 +40,7 @@ int main(int argc, const char** argv) {
     params->parse(XMLfilename);
 
   // Solver
-	SolverI* solver;
+	ISolver* solver;
   std::string string_solver = params->get("solver/description");
 	if 		  (string_solver == SolverTypes::DiffusionSolver) 			   solver=new DiffusionSolver();
 	else if (string_solver == SolverTypes::AdvectionSolver) 			   solver=new AdvectionSolver();

--- a/src/pressure/VCycleMG.h
+++ b/src/pressure/VCycleMG.h
@@ -8,11 +8,11 @@
 #define ARTSS_PRESSURE_VCYCLEMG_H_
 
 #include <vector>
-#include "../interfaces/PressureI.h"
+#include "../interfaces/IPressure.h"
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class VCycleMG: public PressureI{
+class VCycleMG: public IPressure{
 public:
 	VCycleMG(Field* out, Field* b);
 	~VCycleMG() override;

--- a/src/solver/AdvectionDiffusionSolver.cpp
+++ b/src/solver/AdvectionDiffusionSolver.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 
 #include "AdvectionDiffusionSolver.h"
-#include "../interfaces/AdvectionI.h"
+#include "../interfaces/IAdvection.h"
 #include "../utility/Parameters.h"
 #include "../Domain.h"
 #include "SolverSelection.h"
@@ -42,15 +42,15 @@ AdvectionDiffusionSolver::~AdvectionDiffusionSolver() {
 void AdvectionDiffusionSolver::DoStep(real t, bool sync) {
 
 // local variables and parameters
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -78,7 +78,7 @@ void AdvectionDiffusionSolver::DoStep(real t, bool sync) {
         adv->advect(w, w0, u0, v0, w0, sync);
 
 // 2. Couple data to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 3. Solve diffusion equation
         if (nu != 0.) {

--- a/src/solver/AdvectionDiffusionSolver.h
+++ b/src/solver/AdvectionDiffusionSolver.h
@@ -7,12 +7,12 @@
 #ifndef ARTSS_SOLVER_ADVECTIONDIFFUSIONSOLVER_H_
 #define ARTSS_SOLVER_ADVECTIONDIFFUSIONSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class AdvectionDiffusionSolver : public SolverI {
+class AdvectionDiffusionSolver : public ISolver {
 public:
 	AdvectionDiffusionSolver();
 	~AdvectionDiffusionSolver() override;
@@ -20,8 +20,8 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv;
-	DiffusionI* dif;
+	IAdvection* adv;
+	IDiffusion* dif;
 
 	real m_nu;
 

--- a/src/solver/AdvectionSolver.cpp
+++ b/src/solver/AdvectionSolver.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 
 #include "AdvectionSolver.h"
-#include "../interfaces/AdvectionI.h"
+#include "../interfaces/IAdvection.h"
 #include "../utility/Parameters.h"
 #include "../Domain.h"
 #include "SolverSelection.h"
@@ -64,12 +64,12 @@ AdvectionSolver::~AdvectionSolver() {
 // ***************************************************************************************
 void AdvectionSolver::DoStep(real t, bool sync) {
   // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
 
     auto d_u = u->data;
     auto d_v = v->data;

--- a/src/solver/AdvectionSolver.h
+++ b/src/solver/AdvectionSolver.h
@@ -7,11 +7,11 @@
 #ifndef ARTSS_SOLVER_ADVECTIONSOLVER_H_
 #define ARTSS_SOLVER_ADVECTIONSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class AdvectionSolver : public SolverI {
+class AdvectionSolver : public ISolver {
 public:
 	AdvectionSolver();
 	~AdvectionSolver() override;
@@ -19,7 +19,7 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv;
+	IAdvection* adv;
 	Field* u_linm;
 	Field* v_linm;
 	Field* w_linm;

--- a/src/solver/DiffusionSolver.cpp
+++ b/src/solver/DiffusionSolver.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 
 #include "DiffusionSolver.h"
-#include "../interfaces/DiffusionI.h"
+#include "../interfaces/IDiffusion.h"
 #include "../utility/Parameters.h"
 #include "../Domain.h"
 #include "SolverSelection.h"
@@ -39,15 +39,15 @@ void DiffusionSolver::DoStep(real t, bool sync) {
 #endif
 // 1. Solve diffusion equation
     // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
 
     auto d_u = u->data;
     auto d_v = v->data;

--- a/src/solver/DiffusionSolver.h
+++ b/src/solver/DiffusionSolver.h
@@ -7,10 +7,10 @@
 #ifndef ARTSS_SOLVER_DIFFUSIONSOLVER_H_
 #define ARTSS_SOLVER_DIFFUSIONSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/DiffusionI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IDiffusion.h"
 
-class DiffusionSolver: public SolverI {
+class DiffusionSolver: public ISolver {
 public:
 	DiffusionSolver();
 	~DiffusionSolver() override;
@@ -18,7 +18,7 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	DiffusionI* dif;
+	IDiffusion* dif;
 	real m_nu;
 
     static void control();

--- a/src/solver/DiffusionTurbSolver.cpp
+++ b/src/solver/DiffusionTurbSolver.cpp
@@ -43,16 +43,16 @@ void DiffusionTurbSolver::DoStep(real t, bool sync) {
 
 // 1. Solve diffusion equation
 // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto nu_t = SolverI::nu_t;     //Eddy Viscosity
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto nu_t = ISolver::nu_t;     //Eddy Viscosity
 
     auto d_u = u->data;
     auto d_v = v->data;

--- a/src/solver/DiffusionTurbSolver.h
+++ b/src/solver/DiffusionTurbSolver.h
@@ -7,12 +7,12 @@
 #ifndef ARTSS_SOLVER_TURBDIFFUSIONSOLVER_H_
 #define ARTSS_SOLVER_TURBDIFFUSIONSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/ITurbulence.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class DiffusionTurbSolver: public SolverI {
+class DiffusionTurbSolver: public ISolver {
 public:
 	DiffusionTurbSolver();
 	~DiffusionTurbSolver() override;
@@ -20,8 +20,8 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	DiffusionI*   dif;
-	TurbulenceI*  mu_tub;
+	IDiffusion*   dif;
+	ITurbulence*  mu_tub;
 
 	real m_nu;
 

--- a/src/solver/NSSolver.cpp
+++ b/src/solver/NSSolver.cpp
@@ -55,21 +55,21 @@ NSSolver::~NSSolver() {
 void NSSolver::DoStep(real t, bool sync) {
 
 // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto p = SolverI::p;
-    auto p0 = SolverI::p0;
-    auto rhs = SolverI::rhs;
-    auto f_x = SolverI::f_x;
-    auto f_y = SolverI::f_y;
-    auto f_z = SolverI::f_z;
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto p = ISolver::p;
+    auto p0 = ISolver::p0;
+    auto rhs = ISolver::rhs;
+    auto f_x = ISolver::f_x;
+    auto f_y = ISolver::f_y;
+    auto f_z = ISolver::f_z;
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -104,7 +104,7 @@ void NSSolver::DoStep(real t, bool sync) {
 
 
 // Couple velocity to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 2. Solve diffusion equation
         if (nu != 0.) {
@@ -117,7 +117,7 @@ void NSSolver::DoStep(real t, bool sync) {
             dif_vel->diffuse(w, w0, w_tmp, nu, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 3. Add force
@@ -128,7 +128,7 @@ void NSSolver::DoStep(real t, bool sync) {
 #endif
             sou->addSource(u, v, w, f_x, f_y, f_z, sync);
             // Couple data
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 4. Solve pressure equation and project

--- a/src/solver/NSSolver.h
+++ b/src/solver/NSSolver.h
@@ -6,14 +6,14 @@
 #ifndef ARTSS_SOLVER_NSSOLVER_H_
 #define ARTSS_SOLVER_NSSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/SourceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/ISource.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class NSSolver : public SolverI {
+class NSSolver : public ISolver {
 public:
 	NSSolver();
 
@@ -22,10 +22,10 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI *adv_vel;
-	DiffusionI *dif_vel;
-	PressureI *pres;
-	SourceI *sou;
+	IAdvection *adv_vel;
+	IDiffusion *dif_vel;
+	IPressure *pres;
+	ISource *sou;
 
 	real m_nu;
 

--- a/src/solver/NSTempConSolver.cpp
+++ b/src/solver/NSTempConSolver.cpp
@@ -85,29 +85,29 @@ NSTempConSolver::~NSTempConSolver() {
 void NSTempConSolver::DoStep(real t, bool sync) {
 
     // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto p = SolverI::p;
-    auto p0 = SolverI::p0;
-    auto rhs = SolverI::rhs;
-    auto T = SolverI::T;
-    auto T0 = SolverI::T0;
-    auto T_tmp = SolverI::T_tmp;
-    auto C = SolverI::C;
-    auto C0 = SolverI::C0;
-    auto C_tmp = SolverI::C_tmp;
-    auto f_x = SolverI::f_x;
-    auto f_y = SolverI::f_y;
-    auto f_z = SolverI::f_z;
-    auto S_T = SolverI::S_T;
-    auto S_C = SolverI::S_C;
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto p = ISolver::p;
+    auto p0 = ISolver::p0;
+    auto rhs = ISolver::rhs;
+    auto T = ISolver::T;
+    auto T0 = ISolver::T0;
+    auto T_tmp = ISolver::T_tmp;
+    auto C = ISolver::C;
+    auto C0 = ISolver::C0;
+    auto C_tmp = ISolver::C_tmp;
+    auto f_x = ISolver::f_x;
+    auto f_y = ISolver::f_y;
+    auto f_z = ISolver::f_z;
+    auto S_T = ISolver::S_T;
+    auto S_C = ISolver::S_C;
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -152,7 +152,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
         adv_vel->advect(w, w0, u0, v0, w0, sync);
 
         // Couple velocity to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 2. Solve diffusion equation
         if (nu != 0.) {
@@ -165,7 +165,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             dif_vel->diffuse(w, w0, w_tmp, nu, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 3. Add force
@@ -177,7 +177,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             sou_vel->addSource(u, v, w, f_x, f_y, f_z, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 4. Solve pressure equation and project
@@ -203,7 +203,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
         adv_temp->advect(T, T0, u, v, w, sync);
 
         // Couple temperature to prepare for diffusion
-        SolverI::CoupleScalar(T, T0, T_tmp, sync);
+        ISolver::CoupleScalar(T, T0, T_tmp, sync);
 
         // Solve diffusion equation
         if (kappa != 0.) {
@@ -214,7 +214,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             dif_temp->diffuse(T, T0, T_tmp, kappa, sync);
 
             // Couple temperature to prepare for adding source
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
         // Add dissipation
@@ -226,7 +226,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             sou_temp->Dissipate(T, u, v, w, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
         // Add source
@@ -238,7 +238,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             sou_temp->addSource(T, S_T, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
 // 6. Solve for concentration
@@ -250,7 +250,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
         adv_con->advect(C, C0, u, v, w, sync);
 
         // Couple concentration to prepare for diffusion
-        SolverI::CoupleScalar(C, C0, C_tmp, sync);
+        ISolver::CoupleScalar(C, C0, C_tmp, sync);
 
         // Solve diffusion equation
         if (gamma != 0.) {
@@ -261,7 +261,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             dif_con->diffuse(C, C0, C_tmp, gamma, sync);
 
             // Couple concentration to prepare for adding source
-            SolverI::CoupleScalar(C, C0, C_tmp, sync);
+            ISolver::CoupleScalar(C, C0, C_tmp, sync);
         }
 
         // Add source
@@ -273,7 +273,7 @@ void NSTempConSolver::DoStep(real t, bool sync) {
             sou_con->addSource(C, S_C, sync);
 
             // Couple concentration
-            SolverI::CoupleScalar(C, C0, C_tmp, sync);
+            ISolver::CoupleScalar(C, C0, C_tmp, sync);
         }
 
 // 7. Sources updated in Solver::UpdateSources, TimeIntegration

--- a/src/solver/NSTempConSolver.h
+++ b/src/solver/NSTempConSolver.h
@@ -9,14 +9,14 @@
 #define ARTSS_SOLVER_NSTEMPCONSOLVER_H_
 
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/SourceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/ISource.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class NSTempConSolver:public SolverI {
+class NSTempConSolver:public ISolver {
 public:
 	NSTempConSolver();
 	~NSTempConSolver() override;
@@ -24,16 +24,16 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv_vel;
-	DiffusionI* dif_vel;
-	AdvectionI* adv_temp;
-	DiffusionI* dif_temp;
-	AdvectionI* adv_con;
-	DiffusionI* dif_con;
-	PressureI* pres;
-	SourceI* sou_vel;
-	SourceI* sou_temp;
-	SourceI* sou_con;
+	IAdvection* adv_vel;
+	IDiffusion* dif_vel;
+	IAdvection* adv_temp;
+	IDiffusion* dif_temp;
+	IAdvection* adv_con;
+	IDiffusion* dif_con;
+	IPressure* pres;
+	ISource* sou_vel;
+	ISource* sou_temp;
+	ISource* sou_con;
 
 	real m_nu;
 	real m_kappa;

--- a/src/solver/NSTempSolver.cpp
+++ b/src/solver/NSTempSolver.cpp
@@ -72,25 +72,25 @@ NSTempSolver::~NSTempSolver() {
 void NSTempSolver::DoStep(real t, bool sync) {
 
     // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto p = SolverI::p;
-    auto p0 = SolverI::p0;
-    auto rhs = SolverI::rhs;
-    auto T = SolverI::T;
-    auto T0 = SolverI::T0;
-    auto T_tmp = SolverI::T_tmp;
-    auto f_x = SolverI::f_x;
-    auto f_y = SolverI::f_y;
-    auto f_z = SolverI::f_z;
-    auto S_T = SolverI::S_T;
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto p = ISolver::p;
+    auto p0 = ISolver::p0;
+    auto rhs = ISolver::rhs;
+    auto T = ISolver::T;
+    auto T0 = ISolver::T0;
+    auto T_tmp = ISolver::T_tmp;
+    auto f_x = ISolver::f_x;
+    auto f_y = ISolver::f_y;
+    auto f_z = ISolver::f_z;
+    auto S_T = ISolver::S_T;
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -133,7 +133,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
 
 
         // Couple velocity to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 2. Solve diffusion equation
         if (nu != 0.) {
@@ -146,7 +146,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
             dif_vel->diffuse(w, w0, w_tmp, nu, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 3. Add force
@@ -158,7 +158,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
             sou_vel->addSource(u, v, w, f_x, f_y, f_z, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 4. Solve pressure equation and project
@@ -184,7 +184,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
         adv_temp->advect(T, T0, u, v, w, sync);
 
         // Couple temperature to prepare for diffusion
-        SolverI::CoupleScalar(T, T0, T_tmp, sync);
+        ISolver::CoupleScalar(T, T0, T_tmp, sync);
 
         // Solve diffusion equation
         if (kappa != 0.) {
@@ -196,7 +196,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
             dif_temp->diffuse(T, T0, T_tmp, kappa, sync);
 
             // Couple temperature to prepare for adding source
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
         // Add dissipation
@@ -209,7 +209,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
             sou_temp->Dissipate(T, u, v, w, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
         // Add source
@@ -222,7 +222,7 @@ void NSTempSolver::DoStep(real t, bool sync) {
             sou_temp->addSource(T, S_T, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
 // 6. Sources updated in Solver::UpdateSources, TimeIntegration

--- a/src/solver/NSTempSolver.h
+++ b/src/solver/NSTempSolver.h
@@ -8,14 +8,14 @@
 #define ARTSS_SOLVER_NSTEMPSOLVER_H_
 
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/SourceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/ISource.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class NSTempSolver:public SolverI {
+class NSTempSolver:public ISolver {
 public:
 	NSTempSolver();
 	~NSTempSolver() override;
@@ -23,13 +23,13 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv_vel;
-	DiffusionI* dif_vel;
-	AdvectionI* adv_temp;
-	DiffusionI* dif_temp;
-	PressureI* pres;
-	SourceI* sou_vel;
-	SourceI* sou_temp;
+	IAdvection* adv_vel;
+	IDiffusion* dif_vel;
+	IAdvection* adv_temp;
+	IDiffusion* dif_temp;
+	IPressure* pres;
+	ISource* sou_vel;
+	ISource* sou_temp;
 
 	real m_nu;
 	real m_kappa;

--- a/src/solver/NSTempTurbConSolver.cpp
+++ b/src/solver/NSTempTurbConSolver.cpp
@@ -92,32 +92,32 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
     auto params = Parameters::getInstance();
 
     // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto p = SolverI::p;
-    auto p0 = SolverI::p0;
-    auto rhs = SolverI::rhs;
-    auto T = SolverI::T;
-    auto T0 = SolverI::T0;
-    auto T_tmp = SolverI::T_tmp;
-    auto C = SolverI::C;
-    auto C0 = SolverI::C0;
-    auto C_tmp = SolverI::C_tmp;
-    auto f_x = SolverI::f_x;
-    auto f_y = SolverI::f_y;
-    auto f_z = SolverI::f_z;
-    auto S_T = SolverI::S_T;
-    auto S_C = SolverI::S_C;
-    auto nu_t = SolverI::nu_t;            //nu_t - Eddy Viscosity
-    auto kappa_t = SolverI::kappa_t;        //kappa_t - Eddy thermal diffusivity
-    auto gamma_t = SolverI::gamma_t;        //gamma_t - Eddy mass diffsusivity
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto p = ISolver::p;
+    auto p0 = ISolver::p0;
+    auto rhs = ISolver::rhs;
+    auto T = ISolver::T;
+    auto T0 = ISolver::T0;
+    auto T_tmp = ISolver::T_tmp;
+    auto C = ISolver::C;
+    auto C0 = ISolver::C0;
+    auto C_tmp = ISolver::C_tmp;
+    auto f_x = ISolver::f_x;
+    auto f_y = ISolver::f_y;
+    auto f_z = ISolver::f_z;
+    auto S_T = ISolver::S_T;
+    auto S_C = ISolver::S_C;
+    auto nu_t = ISolver::nu_t;            //nu_t - Eddy Viscosity
+    auto kappa_t = ISolver::kappa_t;        //kappa_t - Eddy thermal diffusivity
+    auto gamma_t = ISolver::gamma_t;        //gamma_t - Eddy mass diffsusivity
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -168,7 +168,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
         adv_vel->advect(w, w0, u0, v0, w0, sync);
 
         // Couple velocity to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 2. Solve turbulent diffusion equation
 #ifndef PROFILING
@@ -186,7 +186,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
         dif_vel->diffuse(w, w0, w_tmp, nu, nu_t, sync);
 
         // Couple data to prepare for adding source
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 3. Add force
         if (m_forceFct != SourceMethods::Zero) {
@@ -197,7 +197,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
             sou_vel->addSource(u, v, w, f_x, f_y, f_z, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 4. Solve pressure equation and project
@@ -224,7 +224,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
         adv_temp->advect(T, T0, u, v, w, sync);
 
         // Couple temperature to prepare for diffusion
-        SolverI::CoupleScalar(T, T0, T_tmp, sync);
+        ISolver::CoupleScalar(T, T0, T_tmp, sync);
 
         // Solve diffusion equation
         // turbulence
@@ -244,7 +244,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
             dif_temp->diffuse(T, T0, T_tmp, kappa, kappa_t, sync);
 
             // Couple temperature to prepare for adding source
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         } else {
             // no turbulence
             if (kappa != 0.) {
@@ -256,7 +256,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
                 dif_temp->diffuse(T, T0, T_tmp, kappa, sync);
 
                 // Couple temperature to prepare for adding source
-                SolverI::CoupleScalar(T, T0, T_tmp, sync);
+                ISolver::CoupleScalar(T, T0, T_tmp, sync);
             }
         }
 
@@ -270,7 +270,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
             sou_temp->Dissipate(T, u, v, w, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
             // Add source
@@ -283,7 +283,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
             sou_temp->addSource(T, S_T, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
 // 6. Solve Concentration
@@ -296,7 +296,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
         adv_con->advect(C, C0, u, v, w, sync);
 
         // Couple concentration to prepare for diffusion
-        SolverI::CoupleScalar(C, C0, C_tmp, sync);
+        ISolver::CoupleScalar(C, C0, C_tmp, sync);
 
         // Solve diffusion equation
         // turbulence
@@ -314,7 +314,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
             dif_con->diffuse(C, C0, C_tmp, gamma, gamma_t, sync);
 
             // Couple concentration to prepare for adding source
-            SolverI::CoupleScalar(C, C0, C_tmp, sync);
+            ISolver::CoupleScalar(C, C0, C_tmp, sync);
         } else {
             // no turbulence
             if (gamma != 0.) {
@@ -325,7 +325,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
                 dif_con->diffuse(C, C0, C_tmp, gamma, sync);
 
                 // Couple concentration to prepare for adding source
-                SolverI::CoupleScalar(C, C0, C_tmp, sync);
+                ISolver::CoupleScalar(C, C0, C_tmp, sync);
             }
         }
 
@@ -339,7 +339,7 @@ void NSTempTurbConSolver::DoStep(real t, bool sync) {
             sou_con->addSource(C, S_C, sync);
 
             // Couple concentration
-            SolverI::CoupleScalar(C, C0, C_tmp, sync);
+            ISolver::CoupleScalar(C, C0, C_tmp, sync);
         }
 
 // 7. Sources updated in Solver::UpdateSources, TimeIntegration

--- a/src/solver/NSTempTurbConSolver.h
+++ b/src/solver/NSTempTurbConSolver.h
@@ -15,15 +15,15 @@
 #ifndef NSTEMPTURBCONSOLVER_H_
 #define NSTEMPTURBCONSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/SourceI.h"
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/ISource.h"
+#include "../interfaces/ITurbulence.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class NSTempTurbConSolver:public SolverI {
+class NSTempTurbConSolver:public ISolver {
 public:
 	NSTempTurbConSolver();
 	~NSTempTurbConSolver() override;
@@ -31,17 +31,17 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv_vel;
-	DiffusionI* dif_vel;
-	AdvectionI* adv_temp;
-	DiffusionI* dif_temp;
-	AdvectionI* adv_con;
-	DiffusionI* dif_con;
-	PressureI* pres;
-	SourceI* sou_vel;
-	SourceI* sou_temp;
-	SourceI* sou_con;
-	TurbulenceI*  mu_tub;
+	IAdvection* adv_vel;
+	IDiffusion* dif_vel;
+	IAdvection* adv_temp;
+	IDiffusion* dif_temp;
+	IAdvection* adv_con;
+	IDiffusion* dif_con;
+	IPressure* pres;
+	ISource* sou_vel;
+	ISource* sou_temp;
+	ISource* sou_con;
+	ITurbulence*  mu_tub;
 
 	real m_nu;
 	real m_kappa;

--- a/src/solver/NSTempTurbSolver.cpp
+++ b/src/solver/NSTempTurbSolver.cpp
@@ -76,27 +76,27 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
     auto params = Parameters::getInstance();
 
     // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto p = SolverI::p;
-    auto p0 = SolverI::p0;
-    auto rhs = SolverI::rhs;
-    auto T = SolverI::T;
-    auto T0 = SolverI::T0;
-    auto T_tmp = SolverI::T_tmp;
-    auto f_x = SolverI::f_x;
-    auto f_y = SolverI::f_y;
-    auto f_z = SolverI::f_z;
-    auto S_T = SolverI::S_T;
-    auto nu_t = SolverI::nu_t;            //nu_t - Eddy Viscosity
-    auto kappa_t = SolverI::kappa_t;     //kappa_t - Eddy thermal diffusivity
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto p = ISolver::p;
+    auto p0 = ISolver::p0;
+    auto rhs = ISolver::rhs;
+    auto T = ISolver::T;
+    auto T0 = ISolver::T0;
+    auto T_tmp = ISolver::T_tmp;
+    auto f_x = ISolver::f_x;
+    auto f_y = ISolver::f_y;
+    auto f_z = ISolver::f_z;
+    auto S_T = ISolver::S_T;
+    auto nu_t = ISolver::nu_t;            //nu_t - Eddy Viscosity
+    auto kappa_t = ISolver::kappa_t;     //kappa_t - Eddy thermal diffusivity
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -140,7 +140,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
         adv_vel->advect(w, w0, u0, v0, w0, sync);
 
         // Couple velocity to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 2. Solve turbulent diffusion equation
 #ifndef PROFILING
@@ -159,7 +159,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
         dif_vel->diffuse(w, w0, w_tmp, nu, nu_t, sync);
 
         // Couple data to prepare for adding source
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 3. Add force
         if (m_forceFct != SourceMethods::Zero) {
@@ -170,7 +170,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
             sou_vel->addSource(u, v, w, f_x, f_y, f_z, sync);
 
             // Couple data to prepare for adding source
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 4. Solve pressure equation and project
@@ -197,7 +197,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
         adv_temp->advect(T, T0, u, v, w, sync);
 
         // Couple temperature to prepare for diffusion
-        SolverI::CoupleScalar(T, T0, T_tmp, sync);
+        ISolver::CoupleScalar(T, T0, T_tmp, sync);
 
         // Solve diffusion equation
         // turbulence
@@ -217,7 +217,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
             dif_temp->diffuse(T, T0, T_tmp, kappa, kappa_t, sync);
 
             // Couple temperature to prepare for adding source
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         } else {
             // no turbulence
             if (kappa != 0.) {
@@ -229,7 +229,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
                 dif_temp->diffuse(T, T0, T_tmp, kappa, sync);
 
                 // Couple temperature to prepare for adding source
-                SolverI::CoupleScalar(T, T0, T_tmp, sync);
+                ISolver::CoupleScalar(T, T0, T_tmp, sync);
             }
         }
 
@@ -243,7 +243,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
             sou_temp->Dissipate(T, u, v, w, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
         // Add source
@@ -255,7 +255,7 @@ void NSTempTurbSolver::DoStep(real t, bool sync) {
             sou_temp->addSource(T, S_T, sync);
 
             // Couple temperature
-            SolverI::CoupleScalar(T, T0, T_tmp, sync);
+            ISolver::CoupleScalar(T, T0, T_tmp, sync);
         }
 
 // 6. Sources updated in Solver::UpdateSources, TimeIntegration

--- a/src/solver/NSTempTurbSolver.h
+++ b/src/solver/NSTempTurbSolver.h
@@ -15,15 +15,15 @@
 #ifndef ARTSS_SOLVER_NSTEMPTURBSOLVER_H_
 #define ARTSS_SOLVER_NSTEMPTURBSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/SourceI.h"
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/ISource.h"
+#include "../interfaces/ITurbulence.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class NSTempTurbSolver:public SolverI {
+class NSTempTurbSolver:public ISolver {
 public:
 	NSTempTurbSolver();
 	~NSTempTurbSolver() override;
@@ -31,14 +31,14 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv_vel;
-	DiffusionI* dif_vel;
-	AdvectionI* adv_temp;
-	DiffusionI* dif_temp;
-	PressureI* pres;
-	SourceI* sou_vel;
-	SourceI* sou_temp;
-	TurbulenceI*  mu_tub;
+	IAdvection* adv_vel;
+	IDiffusion* dif_vel;
+	IAdvection* adv_temp;
+	IDiffusion* dif_temp;
+	IPressure* pres;
+	ISource* sou_vel;
+	ISource* sou_temp;
+	ITurbulence*  mu_tub;
 
 	real m_nu;
 	real m_kappa;

--- a/src/solver/NSTurbSolver.cpp
+++ b/src/solver/NSTurbSolver.cpp
@@ -55,22 +55,22 @@ NSTurbSolver::~NSTurbSolver() {
 void NSTurbSolver::DoStep(real t, bool sync) {
 
     // local variables and parameters for GPU
-    auto u = SolverI::u;
-    auto v = SolverI::v;
-    auto w = SolverI::w;
-    auto u0 = SolverI::u0;
-    auto v0 = SolverI::v0;
-    auto w0 = SolverI::w0;
-    auto u_tmp = SolverI::u_tmp;
-    auto v_tmp = SolverI::v_tmp;
-    auto w_tmp = SolverI::w_tmp;
-    auto p = SolverI::p;
-    auto p0 = SolverI::p0;
-    auto rhs = SolverI::rhs;
-    auto f_x = SolverI::f_x;
-    auto f_y = SolverI::f_y;
-    auto f_z = SolverI::f_z;
-    auto nu_t = SolverI::nu_t;     //nu_t - Eddy Viscosity
+    auto u = ISolver::u;
+    auto v = ISolver::v;
+    auto w = ISolver::w;
+    auto u0 = ISolver::u0;
+    auto v0 = ISolver::v0;
+    auto w0 = ISolver::w0;
+    auto u_tmp = ISolver::u_tmp;
+    auto v_tmp = ISolver::v_tmp;
+    auto w_tmp = ISolver::w_tmp;
+    auto p = ISolver::p;
+    auto p0 = ISolver::p0;
+    auto rhs = ISolver::rhs;
+    auto f_x = ISolver::f_x;
+    auto f_y = ISolver::f_y;
+    auto f_z = ISolver::f_z;
+    auto nu_t = ISolver::nu_t;     //nu_t - Eddy Viscosity
 
     auto d_u = u->data;
     auto d_v = v->data;
@@ -107,7 +107,7 @@ void NSTurbSolver::DoStep(real t, bool sync) {
         adv_vel->advect(w, w0, u0, v0, w0, sync);
 
         // Couple velocity to prepare for diffusion
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 2. Solve turbulent diffusion equation
 #ifndef PROFILING
@@ -126,7 +126,7 @@ void NSTurbSolver::DoStep(real t, bool sync) {
         dif_vel->diffuse(w, w0, w_tmp, nu, nu_t, sync);
 
         // Couple data to prepare for adding source
-        SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+        ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
 
 // 3. Add force
         if (m_forceFct != SourceMethods::Zero) {
@@ -138,7 +138,7 @@ void NSTurbSolver::DoStep(real t, bool sync) {
             sou_vel->addSource(u, v, w, f_x, f_y, f_z, sync);
 
             // Couple data
-            SolverI::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
+            ISolver::CoupleVector(u, u0, u_tmp, v, v0, v_tmp, w, w0, w_tmp, sync);
         }
 
 // 4. Solve pressure equation and project

--- a/src/solver/NSTurbSolver.h
+++ b/src/solver/NSTurbSolver.h
@@ -7,15 +7,15 @@
 #ifndef ARTSS_SOLVER_NSTURBSOLVER_H_
 #define ARTSS_SOLVER_NSTURBSOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/SourceI.h"
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/ISource.h"
+#include "../interfaces/ITurbulence.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class NSTurbSolver:public SolverI {
+class NSTurbSolver:public ISolver {
 public:
 	NSTurbSolver();
 	~NSTurbSolver() override;
@@ -23,11 +23,11 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	AdvectionI* adv_vel;
-	DiffusionI* dif_vel;
-	PressureI* pres;
-	SourceI* sou_vel;
-	TurbulenceI*  mu_tub;
+	IAdvection* adv_vel;
+	IDiffusion* dif_vel;
+	IPressure* pres;
+	ISource* sou_vel;
+	ITurbulence*  mu_tub;
 
 	real m_nu;
 

--- a/src/solver/PressureSolver.cpp
+++ b/src/solver/PressureSolver.cpp
@@ -39,8 +39,8 @@ void PressureSolver::DoStep(real t, bool sync) {
 // 1. Solve pressure Poisson equation
 
     // local variables and parameters for GPU
-    auto p = SolverI::p;
-    auto rhs = SolverI::rhs;
+    auto p = ISolver::p;
+    auto rhs = ISolver::rhs;
     auto d_p = p->data;
     auto d_rhs = rhs->data;
 

--- a/src/solver/PressureSolver.h
+++ b/src/solver/PressureSolver.h
@@ -7,11 +7,11 @@
 #ifndef ARTSS_SOLVER_PRESSURESOLVER_H_
 #define ARTSS_SOLVER_PRESSURESOLVER_H_
 
-#include "../interfaces/SolverI.h"
-#include "../interfaces/PressureI.h"
+#include "../interfaces/ISolver.h"
+#include "../interfaces/IPressure.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class PressureSolver: public SolverI {
+class PressureSolver: public ISolver {
 public:
 	PressureSolver();
 	~PressureSolver() override;
@@ -19,7 +19,7 @@ public:
 	void DoStep(real t, bool sync) override;
 
 private:
-	PressureI* pres;
+	IPressure* pres;
 
     static void control();
 };

--- a/src/solver/SolverSelection.cpp
+++ b/src/solver/SolverSelection.cpp
@@ -23,7 +23,7 @@
 /// \param	advectionSolver Pointer to AdvectionSolver
 /// \param  advectionType Name of AdvcetionSolver
 // ***************************************************************************************
-void SolverSelection::SetAdvectionSolver(AdvectionI **advectionSolver, const std::string& advectionType) {
+void SolverSelection::SetAdvectionSolver(IAdvection **advectionSolver, const std::string& advectionType) {
     if (advectionType == AdvectionMethods::SemiLagrangian) {
         *advectionSolver = new SLAdvect();
     } else if (advectionType == AdvectionMethods::Explicit) {
@@ -42,7 +42,7 @@ void SolverSelection::SetAdvectionSolver(AdvectionI **advectionSolver, const std
 /// \param	diffusionSolver Pointer to DiffusionSolver
 /// \param  diffusionType Name of DiffusionSolver
 // ***************************************************************************************
-void SolverSelection::SetDiffusionSolver(DiffusionI **diffusionSolver, const std::string& diffusionType) {
+void SolverSelection::SetDiffusionSolver(IDiffusion **diffusionSolver, const std::string& diffusionType) {
     if (diffusionType == DiffusionMethods::Jacobi) {
         *diffusionSolver = new JacobiDiffuse();
     } else if (diffusionType == DiffusionMethods::ColoredGaussSeidel) {
@@ -63,7 +63,7 @@ void SolverSelection::SetDiffusionSolver(DiffusionI **diffusionSolver, const std
 /// \param	pressureSolver Pointer to PressureSolver
 /// \param  pressureType Name of PressureSolver
 // ***************************************************************************************
-void SolverSelection::SetPressureSolver(PressureI **pressureSolver, const std::string& pressureType, Field *p, Field *rhs) {
+void SolverSelection::SetPressureSolver(IPressure **pressureSolver, const std::string& pressureType, Field *p, Field *rhs) {
     if (pressureType == PressureMethods::VCycleMG) {
         *pressureSolver = new VCycleMG(p, rhs);
     } else {
@@ -80,7 +80,7 @@ void SolverSelection::SetPressureSolver(PressureI **pressureSolver, const std::s
 /// \param	sourceSolver Pointer to SourceSolver
 /// \param  sourceType Name of SourceSolver
 // ***************************************************************************************
-void SolverSelection::SetSourceSolver(SourceI **sourceSolver, const std::string& sourceType) {
+void SolverSelection::SetSourceSolver(ISource **sourceSolver, const std::string& sourceType) {
     if (sourceType == SourceMethods::ExplicitEuler) {
         *sourceSolver = new ExplicitEulerSource();
     } else {
@@ -97,7 +97,7 @@ void SolverSelection::SetSourceSolver(SourceI **sourceSolver, const std::string&
 /// \param	turbulenceSolver Pointer to TurbulenceSolver
 /// \param  turbulenceType Name of TurbulenceSolver
 // ***************************************************************************************
-void SolverSelection::SetTurbulenceSolver(TurbulenceI **turbulenceSolver, const std::string& turbulenceType) {
+void SolverSelection::SetTurbulenceSolver(ITurbulence **turbulenceSolver, const std::string& turbulenceType) {
     if (turbulenceType == TurbulenceMethods::ConstSmagorinsky) {
         *turbulenceSolver = new ConstSmagorinsky();
     } else if (turbulenceType == TurbulenceMethods::DynamicSmagorinsky) {

--- a/src/solver/SolverSelection.h
+++ b/src/solver/SolverSelection.h
@@ -8,11 +8,11 @@
 #define ARTSS_SOLVER_SOLVERSELECTION_H
 
 
-#include "../interfaces/DiffusionI.h"
-#include "../interfaces/SourceI.h"
-#include "../interfaces/PressureI.h"
-#include "../interfaces/AdvectionI.h"
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/IDiffusion.h"
+#include "../interfaces/ISource.h"
+#include "../interfaces/IPressure.h"
+#include "../interfaces/IAdvection.h"
+#include "../interfaces/ITurbulence.h"
 
 struct AdvectionMethods {
     inline static const std::string Explicit = "Explicit";
@@ -46,15 +46,15 @@ struct TurbulenceMethods {
 
 class SolverSelection {
 public:
-    static void SetAdvectionSolver(AdvectionI **advectionSolver, const std::string& advectionType);
+    static void SetAdvectionSolver(IAdvection **advectionSolver, const std::string& advectionType);
 
-    static void SetDiffusionSolver(DiffusionI **diffusionSolver, const std::string& diffusionType);
+    static void SetDiffusionSolver(IDiffusion **diffusionSolver, const std::string& diffusionType);
 
-    static void SetPressureSolver(PressureI **pressureSolver, const std::string& pressureType, Field *p, Field *rhs);
+    static void SetPressureSolver(IPressure **pressureSolver, const std::string& pressureType, Field *p, Field *rhs);
 
-    static void SetSourceSolver(SourceI **sourceSolver, const std::string& sourceType);
+    static void SetSourceSolver(ISource **sourceSolver, const std::string& sourceType);
 
-    static void SetTurbulenceSolver(TurbulenceI **tubulenceSolver, const std::string& turbulenceType);
+    static void SetTurbulenceSolver(ITurbulence **tubulenceSolver, const std::string& turbulenceType);
 };
 
 

--- a/src/source/ExplicitEulerSource.h
+++ b/src/source/ExplicitEulerSource.h
@@ -7,11 +7,11 @@
 #ifndef ARTSS_SOURCE_EXPLICITEULERSOURCE_H_
 #define ARTSS_SOURCE_EXPLICITEULERSOURCE_H_
 
-#include "../interfaces/SourceI.h"
+#include "../interfaces/ISource.h"
 #include "../Field.h"
 #include "../utility/GlobalMacrosTypes.h"
 
-class ExplicitEulerSource: public SourceI {
+class ExplicitEulerSource: public ISource {
 public:
 	ExplicitEulerSource();
 

--- a/src/turbulence/ConstSmagorinsky.h
+++ b/src/turbulence/ConstSmagorinsky.h
@@ -7,9 +7,9 @@
 #ifndef ARTSS_TURBULENCE_CONSTSMAGORINSKY_H_
 #define ARTSS_TURBULENCE_CONSTSMAGORINSKY_H_
 
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/ITurbulence.h"
 
-class ConstSmagorinsky : public TurbulenceI {
+class ConstSmagorinsky : public ITurbulence {
 public:
     ConstSmagorinsky();
 

--- a/src/turbulence/DynamicSmagorinsky.h
+++ b/src/turbulence/DynamicSmagorinsky.h
@@ -7,10 +7,10 @@
 #ifndef ARTSS_TURBULENCE_DYNAMICSMAGORINSKY_H_
 #define ARTSS_TURBULENCE_DYNAMICSMAGORINSKY_H_
 
-#include "../interfaces/TurbulenceI.h"
+#include "../interfaces/ITurbulence.h"
 #include "../Field.h"
 
-class DynamicSmagorinsky: public TurbulenceI {
+class DynamicSmagorinsky: public ITurbulence {
 public:
 	DynamicSmagorinsky();
 	~DynamicSmagorinsky() override;

--- a/src/utility/Visual.cpp
+++ b/src/utility/Visual.cpp
@@ -56,7 +56,7 @@ Visual::Visual() {
 /// \param 	t			time
 /// \param 	fname		xml-file name (via argument)
 // ***************************************************************************************
-void Visual::Visualize(SolverI* solver, const real t, const char *fname){
+void Visual::Visualize(ISolver* solver, const real t, const char *fname){
 
 	auto params = Parameters::getInstance();
 

--- a/src/utility/Visual.h
+++ b/src/utility/Visual.h
@@ -9,12 +9,12 @@
 #define VISUAL_H_
 
 #include "../analysis/Solution.h"
-#include "../interfaces/SolverI.h"
+#include "../interfaces/ISolver.h"
 
 class Visual {
 public:
 	Visual();
-	void Visualize(SolverI* solver, real t, const char *fname);
+	void Visualize(ISolver* solver, real t, const char *fname);
 
 private:
 	void vtkWriteStep(const char *fname, int n, read_ptr u, read_ptr v, read_ptr w, read_ptr p, read_ptr div, read_ptr T, read_ptr C, read_ptr s, read_ptr nu_t, read_ptr S_T, read_ptr ua, read_ptr va, read_ptr wa, read_ptr pa, read_ptr Ta);


### PR DESCRIPTION
Changed the naming of all Interfaces to a more standard naming scheme from:

 "SomeInterfaceI.h" to "ISomeInterface.h" 

for better readability