### PR TITLE
fix: using smaller docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ### author: Sebastian Leifeld
 
-FROM nvcr.io/nvidia/nvhpc:20.11-devel-cuda_multi-ubuntu20.04
+FROM nvcr.io/nvidia/nvhpc:20.11-devel-cuda11.1-ubuntu20.04
 
 RUN apt update
 RUN apt install -y make cmake


### PR DESCRIPTION
fixing #115 by using a smaller image. testing ARTSS with different Cuda versions is now impossible (but not used till now).